### PR TITLE
Created a basic visitor

### DIFF
--- a/src/ir.rs
+++ b/src/ir.rs
@@ -6,7 +6,7 @@ use crate::wrappers::{
     convert_instance_type, convert_instantiation_arg, convert_module_type_declaration,
     convert_params, convert_record_type, convert_results, convert_val_type, convert_variant_case,
     encode_core_type_subtype, process_alias, EncoderComponentExportKind, EncoderComponentTypeRef,
-    EncoderComponentValType, EncoderEntityType, EncoderValType
+    EncoderComponentValType, EncoderEntityType, EncoderValType,
 };
 use wasm_encoder::reencode::Reencode;
 use wasm_encoder::{ComponentAliasSection, ModuleSection};
@@ -94,6 +94,7 @@ pub struct Module<'a> {
     pub custom_sections: Vec<(&'a str, &'a [u8])>,
 }
 
+#[derive(Debug, Clone)]
 pub struct Component<'a> {
     /// Needs to contain:
     /// 1. Modules
@@ -478,10 +479,9 @@ impl<'a> Component<'a> {
         // This function is responsible for visiting every instruction
         for (index, module) in self.modules.into_iter().enumerate() {
             println!("Entered Module: {}", index);
-            for function in module.functions {
-                println!("Entered Function: {}", function);
+            for (idx, body) in module.code_sections.into_iter().enumerate() {
+                println!("Entered Function: {}", idx);
                 // Each function index should match to a code section
-                let body: Body = module.code_sections[function as usize].clone();
                 for (local_idx, local_ty) in body.locals {
                     println!("Local {}: {}", local_idx, local_ty);
                 }
@@ -619,7 +619,8 @@ impl<'a> Module<'a> {
                             func_range: body.range(),
                         });
                     }
-                    let instructions_bool = instructions.into_iter().map(|op| (op, false)).collect();
+                    let instructions_bool =
+                        instructions.into_iter().map(|op| (op, false)).collect();
                     code_sections.push(Body {
                         locals,
                         instructions: instructions_bool,

--- a/tests/round_trip_component.rs
+++ b/tests/round_trip_component.rs
@@ -1,6 +1,6 @@
 use orca::ir::Component;
-use std::io::Write; // bring trait into scope
 use std::fs::File;
+use std::io::Write; // bring trait into scope
 
 fn round_trip_component(testname: &str, folder: &str) {
     let filename = format!(
@@ -12,6 +12,7 @@ fn round_trip_component(testname: &str, folder: &str) {
     let buff = wat::parse_file(filename).expect("couldn't convert the input wat to Wasm");
 
     let component = Component::parse(&buff, false).expect("Unable to parse");
+    component.clone().visitor();
     let result = component.encode().expect("Unable to encode");
     let out = wasmprinter::print_bytes(result).expect("couldn't translated Wasm to wat");
     let original = wasmprinter::print_bytes(buff).expect("couldn't convert original Wasm to wat");
@@ -23,7 +24,7 @@ fn round_trip_component(testname: &str, folder: &str) {
             Err(e) => {
                 eprintln!("Failed to create the file: {}", e);
                 return;
-            },
+            }
         };
 
         // Write the string to the file
@@ -58,8 +59,5 @@ mod round_trip {
         const_expr
     );
 
-    make_round_trip_tests_component!(
-        "handwritten/components",
-        add
-    );
+    make_round_trip_tests_component!("handwritten/components", add);
 }


### PR DESCRIPTION
Created a basic visitor that visits every `local` and `instruction` inside a given code section.
Iterating over code sections instead of functions as `functions: Vec<u32>` maps each function to a given type index.