### PR TITLE
deps: update to Wasmtime 25 toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ include = [
 ]
 
 [dependencies]
-wasm-encoder = { version = "0.215.0", features = ["wasmparser"]}
-wasmparser = "0.215.0"
+wasm-encoder = { version = "0.217.0", features = ["wasmparser"]}
+wasmparser = "0.217.0"
 tempfile = "3.10.1"
 serde_json = "1.0.121"
 log = "0.4.22"

--- a/src/ir/component.rs
+++ b/src/ir/component.rs
@@ -17,7 +17,7 @@ use crate::ir::wrappers::{
 use crate::ir::module::module_functions::FuncKind;
 use crate::ir::module::module_globals::Global;
 use crate::ir::types::CustomSections;
-use wasm_encoder::reencode::Reencode;
+use wasm_encoder::reencode::{Reencode, ReencodeComponent};
 use wasm_encoder::{ComponentAliasSection, ModuleArg, ModuleSection, NestedComponentSection};
 use wasmparser::{
     CanonicalFunction, ComponentAlias, ComponentExport, ComponentImport, ComponentInstance,

--- a/src/ir/wrappers.rs
+++ b/src/ir/wrappers.rs
@@ -1,7 +1,7 @@
 //! Wrapper functions
 
 use std::collections::HashMap;
-use wasm_encoder::reencode::Reencode;
+use wasm_encoder::reencode::{Reencode, ReencodeComponent};
 use wasm_encoder::{
     Alias, ComponentFuncTypeEncoder, ComponentTypeEncoder, CoreTypeEncoder, InstanceType,
 };


### PR DESCRIPTION
Wasmtime has monthly releases on the 19th of the month, which the Jco toolchain aligns with.

In order to avoid toolchain dependency duplication, we align our wasm tools versions with the Wasmtime versions on these releases.

For the current ComponentizeJS release I've had to include two versions of wasmparser. With this PR updating to Wasmparser 217, this would resolve that divergence, which can be posted as a patch release for ComponentizeJS.

Overall it would be great if it might be possible to maintain some kind of release cadence like this with the Wasmtime version.