### PR TITLE
Remove `String` leaks by changing `Import` type

### DIFF
--- a/src/ir/module/mod.rs
+++ b/src/ir/module/mod.rs
@@ -1377,8 +1377,8 @@ impl<'a> Module<'a> {
                         import_func_idx += 1;
                     }
                     imports.import(
-                        import.module,
-                        import.name,
+                        &import.module,
+                        &import.name,
                         reencode.entity_type(import.ty).unwrap(),
                     );
                 }
@@ -1913,8 +1913,8 @@ impl<'a> Module<'a> {
         tag: Tag,
     ) -> (MemoryID, ImportsID) {
         let (imp_mem_id, imp_id) = self.add_import(Import {
-            module: module.leak(),
-            name: name.clone().leak(),
+            module: module.into(),
+            name: name.into(),
             ty: TypeRef::Memory(ty),
             custom_name: None,
             deleted: false,
@@ -1987,8 +1987,8 @@ impl<'a> Module<'a> {
         tag: Tag,
     ) -> (FunctionID, ImportsID) {
         let (imp_fn_id, imp_id) = self.add_import(Import {
-            module: module.leak(),
-            name: name.clone().leak(),
+            module: module.into(),
+            name: name.clone().into(),
             ty: TypeRef::Func(*ty_id),
             custom_name: None,
             deleted: false,
@@ -2068,8 +2068,8 @@ impl<'a> Module<'a> {
         self.delete_func(function_id);
         // Add import function to imports
         let (.., import_id) = self.add_import(Import {
-            module: module.leak(),
-            name: name.clone().leak(),
+            module: module.into(),
+            name: name.clone().into(),
             ty: TypeRef::Func(*ty_id),
             custom_name: None,
             deleted: false,
@@ -2177,8 +2177,8 @@ impl<'a> Module<'a> {
             shared,
         };
         let (imp_global_id, imp_id) = self.add_import(Import {
-            module: module.leak(),
-            name: name.leak(),
+            module: module.into(),
+            name: name.into(),
             ty: TypeRef::Global(global_ty),
             custom_name: None,
             deleted: false,

--- a/src/ir/module/module_imports.rs
+++ b/src/ir/module/module_imports.rs
@@ -1,5 +1,7 @@
 //! Intermediate Representation of a Module's Imports
 
+use std::borrow::Cow;
+
 use crate::ir::id::{FunctionID, ImportsID};
 use crate::ir::types::{InjectTag, Tag, TagUtils};
 use wasmparser::TypeRef;
@@ -9,9 +11,9 @@ use wasmparser::TypeRef;
 #[derive(Debug, Clone)]
 pub struct Import<'a> {
     /// The module being imported from.
-    pub module: &'a str,
+    pub module: Cow<'a, str>,
     /// The name of the imported item.
-    pub name: &'a str,
+    pub name: Cow<'a, str>,
     /// The type of the imported item.
     pub ty: TypeRef,
     /// The name (in the custom section) of the imported item.
@@ -31,8 +33,8 @@ impl TagUtils for Import<'_> {
 impl<'a> From<wasmparser::Import<'a>> for Import<'a> {
     fn from(import: wasmparser::Import<'a>) -> Self {
         Import {
-            module: import.module,
-            name: import.name,
+            module: import.module.into(),
+            name: import.name.into(),
             ty: import.ty,
             custom_name: None,
             deleted: false,


### PR DESCRIPTION
This removes the explicit leaking of strings when adding imports by changing the `Import` struct use `Cow<'_, str>` fields for the module and name. The public functions for adding imports have the same type signature as before.