### PR TITLE
reimplement delete for custom sections

### DIFF
--- a/src/ir/component/mod.rs
+++ b/src/ir/component/mod.rs
@@ -267,6 +267,13 @@ impl<'a> Component<'a> {
         id
     }
 
+    /// Delete a custom section from the component. The visitor and encoder skip deleted entries.
+    pub fn delete_custom_section(&mut self, id: CustomSectionID) {
+        if *id < self.custom_sections.len() as u32 {
+            self.custom_sections.custom_sections[*id as usize].deleted = true;
+        }
+    }
+
     // ── Imports ───────────────────────────────────────────────────────────
     //
     // Each per-kind helper constructs the right `ComponentTypeRef` variant

--- a/src/ir/component/tests.rs
+++ b/src/ir/component/tests.rs
@@ -1322,3 +1322,45 @@ fn concretize_func_import_referencing_borrowed_imported_subresource() {
         "expected NamedResource(\"counter\"), got {param_ty:?}"
     );
 }
+
+// ============================================================
+// Component::delete_custom_section
+// ============================================================
+
+#[test]
+fn test_delete_custom_section_roundtrip() {
+    use crate::ir::types::CustomSection;
+
+    let b = bytes(r#"(component)"#);
+    let mut comp = Component::parse(&b, false, false).unwrap();
+
+    let keep1 = comp.add_custom_section(CustomSection::new("keep1", b"a".to_vec()));
+    let del = comp.add_custom_section(CustomSection::new("del", b"b".to_vec()));
+    let keep2 = comp.add_custom_section(CustomSection::new("keep2", b"c".to_vec()));
+
+    comp.delete_custom_section(del);
+
+    assert_eq!(comp.custom_sections.get_by_id(keep1).unwrap().name, "keep1");
+    assert_eq!(comp.custom_sections.get_by_id(keep2).unwrap().name, "keep2");
+
+    let encoded = comp.encode().expect("encode failed");
+    let reparsed = Component::parse(&encoded, false, false).expect("reparse failed");
+    let names: Vec<&str> = reparsed.custom_sections.iter().map(|s| s.name).collect();
+
+    assert!(names.contains(&"keep1"));
+    assert!(names.contains(&"keep2"));
+    assert!(!names.contains(&"del"));
+}
+
+#[test]
+fn test_delete_custom_section_invalid_id() {
+    use crate::ir::id::CustomSectionID;
+
+    let b = bytes(r#"(component)"#);
+    let mut comp = Component::parse(&b, false, false).unwrap();
+
+    let before = comp.custom_sections.len();
+    comp.delete_custom_section(CustomSectionID(9999));
+
+    assert_eq!(comp.custom_sections.len(), before);
+}

--- a/src/ir/component/visitor/events_structural.rs
+++ b/src/ir/component/visitor/events_structural.rs
@@ -107,7 +107,11 @@ fn visit_comp<'ir>(
                     &component.custom_sections.custom_sections,
                     start_idx,
                     count,
-                    |idx, sect| emit_indexed(out, section_idx, idx, sect, VisitEvent::custom_sect),
+                    |idx, sect| {
+                        if !sect.deleted {
+                            emit_indexed(out, section_idx, idx, sect, VisitEvent::custom_sect)
+                        }
+                    },
                 );
             }
 

--- a/src/ir/component/visitor/events_topological.rs
+++ b/src/ir/component/visitor/events_topological.rs
@@ -488,12 +488,12 @@ impl<'ir> TopoCtx<'ir> {
                     self.collect_core_inst(section_idx, &comp.instances[idx], idx, ctx)
                 }
 
-                ComponentSection::CustomSection => self.collect_custom_section(
-                    section_idx,
-                    &comp.custom_sections.custom_sections[idx],
-                    idx,
-                    ctx,
-                ),
+                ComponentSection::CustomSection => {
+                    let section = &comp.custom_sections.custom_sections[idx];
+                    if !section.deleted {
+                        self.collect_custom_section(section_idx, section, idx, ctx);
+                    }
+                }
 
                 ComponentSection::ComponentStartSection => {
                     self.collect_start_section(section_idx, &comp.start_section[idx], idx, ctx)

--- a/src/ir/module/mod.rs
+++ b/src/ir/module/mod.rs
@@ -1864,6 +1864,9 @@ impl<'a> Module<'a> {
 
         // encode the rest of custom sections
         for section in tmp.custom_sections.iter() {
+            if section.deleted {
+                continue;
+            }
             module.section(&wasm_encoder::CustomSection {
                 name: std::borrow::Cow::Borrowed(section.name),
                 data: section.data.clone(),
@@ -1934,6 +1937,13 @@ impl<'a> Module<'a> {
 
     pub fn add_custom_section(&mut self, section: CustomSection<'a>) -> CustomSectionID {
         self.custom_sections.add(section)
+    }
+
+    /// Delete a custom section from the module. The encoder skips deleted entries.
+    pub fn delete_custom_section(&mut self, id: CustomSectionID) {
+        if *id < self.custom_sections.len() as u32 {
+            self.custom_sections.custom_sections[*id as usize].deleted = true;
+        }
     }
 
     // ===========================

--- a/src/ir/module/test.rs
+++ b/src/ir/module/test.rs
@@ -932,6 +932,46 @@ fn test_custom_sections_integration_with_existing_api() {
 }
 
 #[test]
+fn test_delete_custom_section_roundtrip() {
+    let (buff, _) = setup();
+    let mut module = Module::parse(&buff, false, false).expect("Unable to parse");
+
+    let keep1 = module.add_custom_section(CustomSection::new("keep1", b"a".to_vec()));
+    let del = module.add_custom_section(CustomSection::new("del", b"b".to_vec()));
+    let keep2 = module.add_custom_section(CustomSection::new("keep2", b"c".to_vec()));
+
+    module.delete_custom_section(del);
+
+    assert_eq!(
+        module.custom_sections.get_by_id(keep1).unwrap().name,
+        "keep1"
+    );
+    assert_eq!(
+        module.custom_sections.get_by_id(keep2).unwrap().name,
+        "keep2"
+    );
+
+    let encoded = module.encode().expect("encode failed");
+    let reparsed = Module::parse(&encoded, false, false).expect("reparse failed");
+    let names: Vec<&str> = reparsed.custom_sections.iter().map(|s| s.name).collect();
+
+    assert!(names.contains(&"keep1"));
+    assert!(names.contains(&"keep2"));
+    assert!(!names.contains(&"del"));
+}
+
+#[test]
+fn test_delete_custom_section_invalid_id() {
+    let (buff, _) = setup();
+    let mut module = Module::parse(&buff, false, false).expect("Unable to parse");
+
+    let before = module.custom_sections.len();
+    module.delete_custom_section(CustomSectionID(9999));
+
+    assert_eq!(module.custom_sections.len(), before);
+}
+
+#[test]
 fn test_custom_section_constructors() {
     // Test new() constructor (owned data)
     let owned_data1 = b"data1".to_vec();

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -2195,6 +2195,7 @@ impl<'a> CustomSections<'a> {
 pub struct CustomSection<'a> {
     pub name: &'a str,
     pub data: Cow<'a, [u8]>,
+    pub deleted: bool,
 }
 
 impl<'a> CustomSection<'a> {
@@ -2203,6 +2204,7 @@ impl<'a> CustomSection<'a> {
         CustomSection {
             name,
             data: Cow::Owned(data),
+            deleted: false,
         }
     }
 
@@ -2211,6 +2213,7 @@ impl<'a> CustomSection<'a> {
         CustomSection {
             name,
             data: Cow::Borrowed(data),
+            deleted: false,
         }
     }
 }


### PR DESCRIPTION
Reimplemented delete for custom sections. Using a tombstone approach this time that visitors skip.

context: https://github.com/bytecodealliance/jco/pull/1459

There was some precedence for block comments that seems AI generated and I just copied it for cohesion.